### PR TITLE
fix: fix closing search modal for mobile

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -29,11 +29,13 @@ export function Header() {
 				</div>
 
 				<Search onOpen={onOpen} />
-				<SearchModal
-					onOpen={onOpen}
-					isOpen={isOpen}
-					onOpenChange={onOpenChange}
-				/>
+				{isOpen ? (
+					<SearchModal
+						onOpen={onOpen}
+						isOpen={isOpen}
+						onOpenChange={onOpenChange}
+					/>
+				) : null}
 			</div>
 
 			<Divider />

--- a/src/shared/Search/SearchModal.tsx
+++ b/src/shared/Search/SearchModal.tsx
@@ -25,7 +25,6 @@ export function SearchModal({
 			placement='top'
 			onOpenChange={onOpenChange}
 			size='full'
-			hideCloseButton
 		>
 			<ModalContent className='overflow-auto'>
 				{(onClose) => (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The search modal in the header now only appears when activated, improving interface responsiveness.

- **Style**
  - The search modal now displays its default close button, making it easier for users to close the modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->