### PR TITLE
fix: handle circles_events flat array response

### DIFF
--- a/src/domains/events/repository.ts
+++ b/src/domains/events/repository.ts
@@ -73,7 +73,10 @@ export const eventsRepository = {
 			}
 
 			const eventTypesAmount = new Map<CirclesEventType, number>()
-			const events = response.data.result.events.map((event) => {
+			const rawEvents = Array.isArray(response.data.result)
+				? response.data.result
+				: response.data.result.events
+			const events = rawEvents.map((event) => {
 				eventTypesAmount.set(
 					event.event,
 					(eventTypesAmount.get(event.event) ?? 0) + ONE


### PR DESCRIPTION
## Summary
- `circles_events` returns a flat array `[{event, values}, ...]`
- `circles_events_paginated` returns `{events: [...], hasMore, nextCursor}`
- The explorer called `circles_events` but accessed `result.events` (paginated shape)
- This caused `TypeError: Cannot read properties of undefined (reading 'map')` — breaking the events table on the homepage

## Fix
Handle both response shapes: if `result` is an array, use it directly; otherwise read `result.events`.

## Test plan
- [x] TypeScript compiles without errors
- [ ] Verify events table loads on https://explorer.aboutcircles.com/
- [ ] Verify "Load More" pagination still works
- [ ] Verify address-specific event pages work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event retrieval to handle multiple API response format variations, ensuring reliable and consistent data processing across different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->