### PR TITLE
fix(events): show correct filtered event count and display flow-scope events

### DIFF
--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -105,7 +105,11 @@ export const DEFAULT_FILTER_EVENTS: CirclesEventType[] = [
 
 	// Group creation events
 	'CrcV2_RegisterGroup',
-	'CrcV2_BaseGroupCreated'
+	'CrcV2_BaseGroupCreated',
+
+	// Flow edges scope events
+	'CrcV2_FlowEdgesScopeLastEnded',
+	'CrcV2_FlowEdgesScopeSingleStarted'
 ]
 
 export const LABELS_MAPPER: Record<CirclesEventType, string> = {

--- a/src/shared/EventsTable/EventsTable.tsx
+++ b/src/shared/EventsTable/EventsTable.tsx
@@ -1,12 +1,10 @@
 import { Button } from '@nextui-org/react'
 import type { ReactElement } from 'react'
-import { useMemo } from 'react'
 
 import type { Column, Row } from 'components/VirtualizedTable'
 import { VirtualizedTable } from 'components/VirtualizedTable'
 import { useEventsCoordinator } from 'coordinators'
 import useBreakpoint from 'hooks/useBreakpoint'
-import { useFilterStore } from 'stores/useFilterStore'
 
 import { TotalLabel } from './TotalLabel'
 import { useRenderCell } from './useRenderCell'
@@ -95,19 +93,9 @@ export function EventsTable({
 
 	const renderCell = useRenderCell()
 	const { isSmScreen } = useBreakpoint()
-	const eventTypesAmount = useFilterStore.use.eventTypesAmount()
 
 	// Choose columns based on context
 	const columns = txHash ? transactionColumns : defaultColumns
-
-	// Calculate total events from eventTypesAmount (more efficient)
-	const totalEventsWithSubEvents = useMemo(() => {
-		let total = 0
-		for (const count of eventTypesAmount.values()) {
-			total += count
-		}
-		return total
-	}, [eventTypesAmount])
 
 	const loadMoreButton = isLoadMoreEnabled && (
 		<div className='my-4 flex justify-center'>
@@ -141,9 +129,7 @@ export function EventsTable({
 							isTotalLabelVisible ? (
 								<div className='flex w-full justify-between'>
 									<div className='flex flex-row'>
-										<TotalLabel
-											totalEventsWithSubEvents={totalEventsWithSubEvents}
-										/>
+										<TotalLabel totalEvents={events.length} />
 									</div>
 								</div>
 							) : undefined
@@ -158,9 +144,7 @@ export function EventsTable({
 					<div className='flex flex-col items-center justify-center'>
 						{isTotalLabelVisible ? (
 							<div className='mb-2'>
-								<TotalLabel
-									totalEventsWithSubEvents={totalEventsWithSubEvents}
-								/>
+								<TotalLabel totalEvents={events.length} />
 							</div>
 						) : null}
 

--- a/src/shared/EventsTable/TotalLabel.tsx
+++ b/src/shared/EventsTable/TotalLabel.tsx
@@ -9,10 +9,10 @@ import { useBlockNumber } from 'services/viemClient'
 import { useFilterStore } from 'stores/useFilterStore'
 
 interface TotalLabelProperties {
-	totalEventsWithSubEvents: number
+	totalEvents: number
 }
 
-export function TotalLabel({ totalEventsWithSubEvents }: TotalLabelProperties) {
+export function TotalLabel({ totalEvents }: TotalLabelProperties) {
 	const { currentStartBlock, defaultStartBlock } = useStartBlock()
 	const clearStartBlock = useFilterStore.use.clearStartBlock()
 	const blockNumber = useBlockNumber()
@@ -39,7 +39,7 @@ export function TotalLabel({ totalEventsWithSubEvents }: TotalLabelProperties) {
 			<span className='text-small text-default-400'>
 				<span className='font-semibold text-black'>
 					Total Events:{' '}
-					{totalEventsWithSubEvents === 0 ? '...' : totalEventsWithSubEvents}
+					{totalEvents === 0 ? '...' : totalEvents}
 				</span>
 				<span className='ml-2 text-small text-default-400'>
 					(From Block: {currentStartBlock}

--- a/src/shared/EventsTable/useRenderCell.tsx
+++ b/src/shared/EventsTable/useRenderCell.tsx
@@ -218,6 +218,20 @@ export const useRenderCell = () => {
 						)
 					}
 
+					// Handle FlowEdgesScope events
+					if (item.flowEdgeId || item.streamId) {
+						return (
+							<div className='flex flex-col text-sm text-default-500'>
+								{item.flowEdgeId ? (
+									<span>Flow Edge: {String(item.flowEdgeId)}</span>
+								) : null}
+								{item.streamId ? (
+									<span>Stream: {String(item.streamId)}</span>
+								) : null}
+							</div>
+						)
+					}
+
 					return ''
 				}
 				case 'blockNumber': {


### PR DESCRIPTION
## Summary

Fixes two related issues with the events table:

1. **Misleading event counter**: `TotalLabel` displayed the raw fetched event count (from cache) instead of the filtered count, causing "Total Events: 100" to appear while the table showed "No rows to display".

2. **Flow-scope events invisible**: `CrcV2_FlowEdgesScopeLastEnded` and `CrcV2_FlowEdgesScopeSingleStarted` events were returned by the RPC but filtered out by `DEFAULT_FILTER_EVENTS`.

## Changes

- `EventsTable.tsx`: Pass `events.length` (already filtered) to `TotalLabel` instead of computing `totalEventsWithSubEvents` from raw cache data
- `TotalLabel.tsx`: Rename prop from `totalEventsWithSubEvents` to `totalEvents`
- `constants/events.ts`: Add flow-scope events to `DEFAULT_FILTER_EVENTS`
- `useRenderCell.tsx`: Add `details` renderer for flow-scope events showing `flowEdgeId` and `streamId`

## Testing

- Build passes (`npm run build`)
- Unit test verified: `processEvents` with updated `DEFAULT_FILTER_EVENTS` keeps all 100 flow-scope events (previously 0 passed through)