### PR TITLE
Resolve true inviter for RegisterHuman events via InvitationModule

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -28,5 +28,7 @@ export const DECIMAL_RADIX = 10
 
 export const MIGRATION_CONTRACT = '0xD44B8dcFBaDfC78EA64c55B705BFc68199B56376'
 
+export const INVITATION_MODULE_ADDRESS = '0x00738aca013b7b2e6cfe1690f0021c3182fa40b5'
+
 // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
 export const CRC_MIGRATION_DENOMINATION = 2.216_690_071_905_145_5

--- a/src/domains/avatars/repository.ts
+++ b/src/domains/avatars/repository.ts
@@ -255,27 +255,18 @@ export const avatarRepository = {
 	getInvitedBy: async (address: Address): Promise<Address | undefined> => {
 		try {
 			const LIMIT_ONE = 1
-			// todo: it'll be changed to circlesData.getInvitedBy after sdk fix
-			const query = new CirclesQuery<{
-				blockNumber: number
-				timestamp: number
-				transactionIndex: number
-				logIndex: number
+
+			// Query Hub RegisterHuman and InvitationModule RegisterHuman in parallel.
+			// The InvitationModule stores the true originInviter when an invitation was
+			// paid via a proxy account; the Hub event only records the proxy inviter.
+			const hubQuery = new CirclesQuery<{
 				transactionHash: string
 				avatar: Address
 				inviter: Address
 			}>(circlesData.rpc, {
 				namespace: 'CrcV2',
 				table: 'RegisterHuman',
-				columns: [
-					'blockNumber',
-					'timestamp',
-					'transactionIndex',
-					'logIndex',
-					'transactionHash',
-					'avatar',
-					'inviter'
-				],
+				columns: ['transactionHash', 'avatar', 'inviter'],
 				filter: [
 					{
 						Type: 'FilterPredicate',
@@ -288,12 +279,39 @@ export const avatarRepository = {
 				limit: LIMIT_ONE
 			})
 
-			const hasResults = await query.queryNextPage()
-			if (!hasResults || !query.currentPage?.results.length) {
+			const moduleQuery = new CirclesQuery<{
+				human: Address
+				originInviter: Address
+			}>(circlesData.rpc, {
+				namespace: 'CrcV2_InvitationsAtScale',
+				table: 'RegisterHuman',
+				columns: ['human', 'originInviter'],
+				filter: [
+					{
+						Type: 'FilterPredicate',
+						FilterType: 'Equals',
+						Column: 'human',
+						Value: address.toLowerCase()
+					}
+				],
+				sortOrder: 'DESC',
+				limit: LIMIT_ONE
+			})
+
+			const [hasHubResults, hasModuleResults] = await Promise.all([
+				hubQuery.queryNextPage(),
+				moduleQuery.queryNextPage()
+			])
+
+			if (!hasHubResults || !hubQuery.currentPage?.results.length) {
 				return undefined
 			}
 
-			return query.currentPage.results[0].inviter
+			if (hasModuleResults && moduleQuery.currentPage?.results.length) {
+				return moduleQuery.currentPage.results[0].originInviter
+			}
+
+			return hubQuery.currentPage.results[0].inviter
 		} catch (error) {
 			logger.error('[Repository] Failed to fetch invited by:', error)
 			return undefined

--- a/src/domains/events/repository.ts
+++ b/src/domains/events/repository.ts
@@ -32,6 +32,60 @@ import type {
 	PageResult
 } from './types'
 
+const INVITATION_MODULE_NAMESPACE = 'CrcV2_InvitationsAtScale'
+
+/**
+ * Queries the InvitationModule index for originInviter by transaction hash.
+ * Returns a map of transactionHash -> originInviter for any matches found.
+ * When an invitation was paid via a proxy account the Hub RegisterHuman event
+ * records the proxy as inviter; this lookup surfaces the true origin inviter.
+ */
+const fetchOriginInviters = async (
+	txHashes: string[]
+): Promise<Map<string, string>> => {
+	try {
+		const response = await axios.post<{
+			result: { columns: string[]; rows: string[][] }
+		}>(CIRCLES_INDEXER_URL, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'circles_query',
+			params: [
+				{
+					Namespace: INVITATION_MODULE_NAMESPACE,
+					Table: 'RegisterHuman',
+					Columns: ['transactionHash', 'originInviter'],
+					Filter: [
+						{
+							Type: 'FilterPredicate',
+							FilterType: 'In',
+							Column: 'transactionHash',
+							Value: txHashes
+						}
+					],
+					Order: [],
+					Limit: txHashes.length
+				}
+			]
+		})
+
+		if (!response.data.result) return new Map()
+
+		const { columns, rows } = response.data.result
+		const txHashIdx = columns.indexOf('transactionHash')
+		const originInviterIdx = columns.indexOf('originInviter')
+
+		const map = new Map<string, string>()
+		for (const row of rows) {
+			map.set(row[txHashIdx], row[originInviterIdx])
+		}
+		return map
+	} catch (error) {
+		logger.error('[Repository] Failed to fetch origin inviters', error)
+		return new Map()
+	}
+}
+
 // Query keys
 const CIRCLES_EVENTS_INFINITE_QUERY_KEY = 'circlesEventsInfinite'
 export const eventsKeys = {
@@ -96,6 +150,34 @@ export const eventsRepository = {
 					)
 				}
 			})
+
+			// For any CrcV2_RegisterHuman events, replace the Hub-level proxy inviter
+			// with the true origin inviter from the InvitationModule when available.
+			const registerHumanTxHashes = events
+				.filter((e) => e.event === 'CrcV2_RegisterHuman')
+				.map((e) => e.transactionHash)
+
+			if (registerHumanTxHashes.length > 0) {
+				const originInviters =
+					await fetchOriginInviters(registerHumanTxHashes)
+
+				if (originInviters.size > 0) {
+					const enrichedEvents = events.map((event) => {
+						if (event.event !== 'CrcV2_RegisterHuman') return event
+						const originInviter = originInviters.get(event.transactionHash)
+						return originInviter
+							? { ...event, inviter: originInviter }
+							: event
+					})
+
+					logger.log(
+						'[Repository] Queried circles events',
+						`Event count: ${enrichedEvents.length}, startBlock: ${startBlock}, endBlock: ${endBlock}`
+					)
+
+					return { events: enrichedEvents, eventTypesAmount }
+				}
+			}
 
 			logger.log(
 				'[Repository] Queried circles events',


### PR DESCRIPTION
## Summary
This PR enhances inviter resolution by querying the InvitationModule to surface the true origin inviter when an invitation was paid via a proxy account. The Hub's RegisterHuman event only records the proxy as the inviter, while the InvitationModule stores the actual origin inviter.

## Key Changes
- **Events Repository**: Added `fetchOriginInviters()` function to query the InvitationModule's RegisterHuman table by transaction hash and enrich CrcV2_RegisterHuman events with the true origin inviter when available
- **Avatars Repository**: Updated `getInvitedBy()` to query both the Hub and InvitationModule RegisterHuman tables in parallel, preferring the InvitationModule's originInviter when available
- **Constants**: Added `INVITATION_MODULE_ADDRESS` constant for reference

## Implementation Details
- The `fetchOriginInviters()` function creates a map of transactionHash → originInviter from the InvitationModule, with graceful error handling that returns an empty map on failure
- Events enrichment only occurs when origin inviters are found, maintaining backward compatibility
- The avatar inviter lookup uses `Promise.all()` to query both sources concurrently, with preference given to the InvitationModule's data when available
- Simplified Hub query columns to only fetch necessary fields (transactionHash, avatar, inviter)

https://claude.ai/code/session_014kgccDque5pcE3o71cv4Hk