### PR TITLE
fix(bots): migrate bot analytics endpoint to production host

### DIFF
--- a/src/domains/bots/repository.ts
+++ b/src/domains/bots/repository.ts
@@ -7,9 +7,7 @@ import logger from 'services/logger'
 
 import type { BotApiResponse, BotVerdict, BotVerdictMap } from './types'
 
-// API endpoint for bot detection
-const BOT_API_URL =
-	'https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/bot-analytics/classify'
+const BOT_API_URL = 'https://rpc.aboutcircles.com/analytics/bot-analytics/classify'
 
 // Cache time constants
 const BOT_CACHE_MINUTES = 30


### PR DESCRIPTION
## Summary

- Replaces hardcoded DigitalOcean App Platform URL with the production analytics endpoint at `rpc.aboutcircles.com/analytics/bot-analytics/classify`
- Response schema is identical (`verdicts[]` with `address`, `is_bot`, `category`, `reason`) — no type changes needed
- Endpoint verified live before shipping: returns correct `200` responses

## Test plan

- [ ] Bot labels render correctly on avatar pages
- [ ] Bot warning banner appears for flagged addresses
- [ ] No errors in console for bot verdict fetches